### PR TITLE
Fix sourceUrl in EnabledControl schema and fix CodeUri in SAM template

### DIFF
--- a/aws-controltower-enabledcontrol/aws-controltower-enabledcontrol.json
+++ b/aws-controltower-enabledcontrol/aws-controltower-enabledcontrol.json
@@ -1,7 +1,7 @@
 {
   "typeName": "AWS::ControlTower::EnabledControl",
   "description": "Enables a control on a specified target.",
-  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-controltower",
   "properties": {
     "ControlIdentifier": {
       "description": "Arn of the control.",

--- a/aws-controltower-enabledcontrol/template.yml
+++ b/aws-controltower-enabledcontrol/template.yml
@@ -13,11 +13,11 @@ Resources:
     Properties:
       Handler: software.amazon.controltower.enabledcontrol.HandlerWrapper::handleRequest
       Runtime: java8
-      CodeUri: ./target/aws-controltower-enabledcontrol-1.0-SNAPSHOT.jar
+      CodeUri: ./target/aws-controltower-enabledcontrol-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.controltower.enabledcontrol.HandlerWrapper::testEntrypoint
       Runtime: java8
-      CodeUri: ./target/aws-controltower-enabledcontrol-1.0-SNAPSHOT.jar
+      CodeUri: ./target/aws-controltower-enabledcontrol-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Description of changes:*

* Modify sourceUrl to point to the controltower github repository
* Modify AWS SAM template to generate the correct target jar file from `mvn package` 

*Testing*
mvn package && mvn verify succeeded. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
