### PR TITLE
Add max_results parameter to ReadAPI request

### DIFF
--- a/aws-controltower-enabledcontrol/src/main/java/software/amazon/controltower/enabledcontrol/ReadHandler.java
+++ b/aws-controltower-enabledcontrol/src/main/java/software/amazon/controltower/enabledcontrol/ReadHandler.java
@@ -28,6 +28,8 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
     private AmazonWebServicesClientProxy clientProxy;
     private Logger logger;
 
+    public static final int MAX_RESULTS = 40;
+
     public ReadHandler() {
         controlTowerClient = ClientBuilder.getStandardClient(logger);
     }
@@ -55,6 +57,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
             do {
                 final ListEnabledControlsRequest listEnabledControlsRequest = new ListEnabledControlsRequest()
                         .withTargetIdentifier(model.getTargetIdentifier())
+                        .withMaxResults(MAX_RESULTS)
                         .withNextToken(nextToken);
                 final ListEnabledControlsResult listEnabledControlsResult = clientProxy.injectCredentialsAndInvoke(
                         listEnabledControlsRequest, controlTowerClient::listEnabledControls);


### PR DESCRIPTION
*Description of changes:*
This change increases the MAX_RESULTS returned by listEnabledControls API call. By default listEnabledControls API returns 20 records, with this change it will return 40 records. This reduces the number of Read API calls we need to make to check if a guardrail already exists.

*Testing*
`mvn verify` succeeded
`create stack` succeeded
`delete stack` succeeded

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
