### PR TITLE
Add error message to failed progress event

### DIFF
--- a/aws-controltower-enabledcontrol/docs/README.md
+++ b/aws-controltower-enabledcontrol/docs/README.md
@@ -60,3 +60,4 @@ _Maximum Length_: <code>2048</code>
 _Pattern_: <code>^arn:aws[0-9a-zA-Z_\-:\/]+$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+

--- a/aws-controltower-enabledcontrol/docs/README.md
+++ b/aws-controltower-enabledcontrol/docs/README.md
@@ -60,4 +60,3 @@ _Maximum Length_: <code>2048</code>
 _Pattern_: <code>^arn:aws[0-9a-zA-Z_\-:\/]+$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
-

--- a/aws-controltower-enabledcontrol/src/main/java/software/amazon/controltower/enabledcontrol/CreateHandler.java
+++ b/aws-controltower-enabledcontrol/src/main/java/software/amazon/controltower/enabledcontrol/CreateHandler.java
@@ -80,7 +80,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                             .build();
                 }
             } catch (BaseHandlerException e) {
-                logger.log(String.format("StackId [%s] readHandler failed with an exception %s", request.getStackId(), e.getErrorCode()));
+                logger.log(String.format("StackId [%s] readHandler failed with an exception %s %s", request.getStackId(), e.getErrorCode(), e.getMessage()));
                 return ProgressEvent.<ResourceModel, CallbackContext>builder()
                         .status(OperationStatus.FAILED)
                         .errorCode(e.getErrorCode())

--- a/aws-controltower-enabledcontrol/src/main/java/software/amazon/controltower/enabledcontrol/CreateHandler.java
+++ b/aws-controltower-enabledcontrol/src/main/java/software/amazon/controltower/enabledcontrol/CreateHandler.java
@@ -84,6 +84,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 return ProgressEvent.<ResourceModel, CallbackContext>builder()
                         .status(OperationStatus.FAILED)
                         .errorCode(e.getErrorCode())
+                        .message(e.getMessage())
                         .build();
             } catch (Throwable e) {
                 throw new CfnInternalFailureException(e);

--- a/aws-controltower-enabledcontrol/src/test/java/software/amazon/controltower/enabledcontrol/CreateHandlerTest.java
+++ b/aws-controltower-enabledcontrol/src/test/java/software/amazon/controltower/enabledcontrol/CreateHandlerTest.java
@@ -440,5 +440,6 @@ public class CreateHandlerTest {
         assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+        assertThat(response.getMessage()).isNotNull();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The create handler calls the read handler to check if the resource already exists. If the read handler throws an error, we need to include the message field in the failed progress event. Otherwise, the cfn stack event message just displays `Resource handler returned message: "null"`. 

I tested this via sam and verified the message shows up in cfn console:

```
(rpdk) ➜  aws-controltower-enabledcontrol git:(error-messaging) ✗ cfn invoke resource CREATE test.json
Resource schema is valid.
=== Handler input ===
{
  "callbackContext": null,
  "action": "CREATE",
  "requestData": {
    "resourceProperties": {
      "ControlIdentifier": "arn:aws:controltower:us-east-1::control/AWS-GR_AUDIT_BUCKET_POLICY_CHANGES_PROHIBITED",
      "TargetIdentifier": "arn:aws:organizations::..."
    },
    "previousResourceProperties": {}
  },
  "region": "us-east-1",
  "awsAccountId": "...",
  "bearerToken": "f2817bef-007d-4d94-ac6f-f0bc5e5edb10"
}
=== Handler response ===
{
  "status": "FAILED",
  "errorCode": "NotFound",
  "message": "Organizational unit ... is not registered with AWS Control Tower. (Service: AWSControlTower; Status Code: 404; Error Code: ResourceNotFoundException; Request ID: 1775626d-996f-4fff-9300-f91fd9a182dc; Proxy: null)",
  "callbackDelaySeconds": 0
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
